### PR TITLE
k8s: Start core and helm for jenkins master

### DIFF
--- a/devops_CI_CD/k8s/core/namespaces/jenkins.yaml
+++ b/devops_CI_CD/k8s/core/namespaces/jenkins.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jenkins
+  labels:
+    name: jenkins
+    purpose: ci-cd

--- a/devops_CI_CD/k8s/core/rbac/jenkins-roles.yaml
+++ b/devops_CI_CD/k8s/core/rbac/jenkins-roles.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jenkins-role
+  namespace: jenkins
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/exec", "pods/log", "services", "configmaps", "secrets"]
+    verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "delete", "get", "list", "watch", "patch", "update"]

--- a/devops_CI_CD/k8s/core/rbac/jenkins-serviceaccount.yaml
+++ b/devops_CI_CD/k8s/core/rbac/jenkins-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins
+  namespace: jenkins
+  labels:
+    app: jenkins

--- a/devops_CI_CD/k8s/core/storage/pvc-jenkins.yaml
+++ b/devops_CI_CD/k8s/core/storage/pvc-jenkins.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jenkins-pvc
+  namespace: jenkins
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+  storageClassName: standard

--- a/devops_CI_CD/k8s/helm-charts/jenkins/Chart.yaml
+++ b/devops_CI_CD/k8s/helm-charts/jenkins/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: jenkins
+description: Jenkins Master for Minikube-based CI/CD cluster
+type: application
+version: 0.1.0
+appVersion: "2.492.3"

--- a/devops_CI_CD/k8s/helm-charts/jenkins/templates/configmap.yaml
+++ b/devops_CI_CD/k8s/helm-charts/jenkins/templates/configmap.yaml
@@ -1,0 +1,9 @@
+# k8s/helm-charts/jenkins/templates/jenkins-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jenkins-config
+  labels:
+    app: jenkins
+data:
+  JENKINS_OPTS: "--argumentsRealm.passwd.{{ .Values.adminCredentials.user }}={{ .Values.adminCredentials.password }} --argumentsRealm.roles.admin=admin"

--- a/devops_CI_CD/k8s/helm-charts/jenkins/templates/deployment.yaml
+++ b/devops_CI_CD/k8s/helm-charts/jenkins/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins-master
+  labels:
+    app: jenkins
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jenkins
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
+      containers:
+        - name: jenkins
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+            - containerPort: {{ .Values.service.agentPort }}
+          volumeMounts:
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
+          env:
+            - name: JENKINS_ADMIN_ID
+              value: "{{ .Values.adminCredentials.user }}"
+            - name: JENKINS_ADMIN_PASSWORD
+              value: "{{ .Values.adminCredentials.password }}"
+      volumes:
+        - name: jenkins-home
+          persistentVolumeClaim:
+            claimName: jenkins-pvc

--- a/devops_CI_CD/k8s/helm-charts/jenkins/templates/service.yaml
+++ b/devops_CI_CD/k8s/helm-charts/jenkins/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins-master
+  labels:
+    app: jenkins
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      nodePort: {{ .Values.service.nodePort }}
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.agentPort }}
+      targetPort: {{ .Values.service.agentPort }}
+      protocol: TCP
+      name: agent
+  selector:
+    app: jenkins

--- a/devops_CI_CD/k8s/helm-charts/jenkins/values.yaml
+++ b/devops_CI_CD/k8s/helm-charts/jenkins/values.yaml
@@ -1,0 +1,37 @@
+image:
+  repository: jenkins/jenkins
+  tag: lts
+  pullPolicy: IfNotPresent
+
+service:
+  type: NodePort
+  port: 8080
+  targetPort: 8080
+  agentPort: 50000
+  nodePort: 30080  
+
+persistence:
+  enabled: true
+  storageClass: standard
+  accessModes:
+    - ReadWriteOnce
+  size: 8Gi
+  existingClaim: ""  
+
+
+resources:
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+
+adminCredentials:
+  user: admin
+  password: admin
+
+controller:
+  serviceAccount:
+    create: false   # No queremos que Helm cree uno nuevo
+    name: jenkins


### PR DESCRIPTION
Changes Introduced
Namespace: Created jenkins namespace with appropriate labels (purpose: ci-cd).

RBAC: Created jenkins-role with permissions over Pods, Services, ConfigMaps, Secrets, and Deployments.

Created jenkins-serviceaccount linked to the jenkins namespace.

Storage: Created PersistentVolumeClaim (jenkins-pvc) with 8Gi storage for Jenkins' home directory.

Helm Chart: Added Helm chart for Jenkins: Chart.yaml metadata defined. values.yaml parameterized (image, service type/ports, persistence settings, resources, admin credentials).

Configured templates: configmap.yaml (Jenkins options and admin credentials)
deployment.yaml (Jenkins master deployment with PVC and environment variables)
service.yaml (NodePort service exposing Jenkins).

