### PR TITLE
Infra gcp

### DIFF
--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -7,7 +7,7 @@ pipeline {
   }
   
   environment {
-    TF_DIR = "terraform/aws" // Cambia si tu estructura del repo es distinta
+    TF_DIR = "devops_CI_CD/terraform/aws" 
   }
 
   options {

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -13,106 +13,103 @@ pipeline {
   }
 
   options {
-    timestamps()
-  }
+        timestamps()
+    }
 
-  stages {
-    stage('Prepare Environment') {
-      steps {
-        echo "[STEP] Starting environment preparation..."
-        dir("${TF_DIR}") {
-          sh '''
-            echo "[INFO] Current Terraform working directory: $(pwd)"
-            terraform version
-          '''
+    stages {
+
+        stage('Cleanup Before Checkout') {
+            steps {
+                deleteDir()
+            }
         }
-      }
-    }
 
-    stage('Terraform Init') {
-      steps {
-        withCredentials([
-          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
-          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
-        ]) {
-          dir("${TF_DIR}") {
-            sh '''
-              echo "[STEP] Exporting Terraform Cloud Token..."
-              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
-
-              echo "[STEP] Initializing Terraform backend (only for tfstate)..."
-              rm -rf .terraform
-              terraform init -input=false
-            '''
-          }
+        stage('Checkout') {
+            steps {
+                echo "[INFO] Checking out repository..."
+                checkout scm
+            }
         }
-      }
-    }
 
-    stage('Terraform Validate & Format') {
-      steps {
-        dir("${TF_DIR}") {
-          sh '''
-            echo "[STEP] Formatting and validating Terraform code..."
-            terraform fmt -check
-            terraform validate
-          '''
+        stage('Terraform Init') {
+            steps {
+                withCredentials([
+                    [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+                    [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
+                ]) {
+                    dir("${TF_DIR}") {
+                        echo "[DEBUG] Initializing Terraform..."
+                        sh '''
+                          rm -rf .terraform
+                          terraform init -input=false
+                        '''
+                    }
+                }
+            }
         }
-      }
-    }
 
-    stage('Terraform Plan (Local Execution)') {
-      steps {
-        withCredentials([
-          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
-          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
-        ]) {
-          dir("${TF_DIR}") {
-            sh '''
-              echo "[STEP] Forcing local Terraform plan execution..."
-              export TF_CLI_ARGS_plan="-input=false -lock=false -no-color"
-              export TF_IN_AUTOMATION=true
-              export TF_CLOUD=false
-
-              terraform plan -out=${PLAN_OUT} | tee ${PLAN_SUMMARY}
-            '''
-          }
+        stage('Terraform Validate & Format') {
+            steps {
+                dir("${TF_DIR}") {
+                    echo "[DEBUG] Formatting and validating Terraform code..."
+                    sh 'terraform fmt -check'
+                    sh 'terraform validate'
+                }
+            }
         }
-      }
-    }
 
-    stage('Terraform Apply (Local Execution)') {
-      steps {
-        input message: "[APPROVAL] Confirm Apply: Do you want to deploy these changes to AWS?"
-        withCredentials([
-          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
-          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
-        ]) {
-          dir("${TF_DIR}") {
-            sh '''
-              echo "[STEP] Forcing local Terraform apply execution..."
-              export TF_IN_AUTOMATION=true
-              export TF_CLOUD=false
+        stage('Terraform Plan') {
+            steps {
+                withCredentials([
+                    [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
+                ]) {
+                    dir("${TF_DIR}") {
+                        echo "[DEBUG] Forcing local terraform plan"
+                        sh '''
+                            export TF_CLI_ARGS_plan="-input=false -lock=false -no-color"
+                            export TF_IN_AUTOMATION=true
+                            export TF_CLOUD=false
 
-              terraform apply -input=false ${PLAN_OUT}
-            '''
-          }
+                            terraform plan -out=${PLAN_OUT} | tee ${PLAN_SUMMARY}
+                        '''
+                    }
+                }
+            }
         }
-      }
-    }
-  }
 
-  post {
-    success {
-      echo "[SUCCESS] Terraform apply completed successfully. Infrastructure is deployed."
+        stage('Terraform Apply') {
+            when {
+                expression {
+                    return currentBuild.currentResult == 'SUCCESS'
+                }
+            }
+            steps {
+                withCredentials([
+                    [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
+                ]) {
+                    dir("${TF_DIR}") {
+                        echo "[INFO] Applying Terraform changes..."
+                        sh '''
+                            export TF_IN_AUTOMATION=true
+                            export TF_CLOUD=false
+                            terraform apply -auto-approve
+                        '''
+                    }
+                }
+            }
+        }
     }
-    failure {
-      echo "[FAILURE] Terraform process failed. Please review logs."
+
+    post {
+        success {
+            echo "[SUCCESS] Terraform plan pipeline completed successfully."
+        }
+        failure {
+            echo "[FAILURE] Terraform plan pipeline failed. See logs for details."
+        }
+        always {
+            echo "[FINAL] Pipeline finished with status: ${currentBuild.result}"
+            cleanWs()
+        }
     }
-    always {
-      sh '''
-        echo "[INFO] Pipeline finished at: $(date)"
-      '''
-    }
-  }
 }

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -84,7 +84,6 @@ pipeline {
 
     stage('Terraform Apply (Local Execution)') {
       steps {
-        input message: "[APPROVAL] Confirm Apply: Do you want to deploy these changes to AWS?"
         withCredentials([
           [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
           [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -7,11 +7,13 @@ pipeline {
   }
   
   environment {
-    TF_DIR = "devops_CI_CD/terraform/aws" 
+    TF_DIR = "devops_CI_CD/terraform/aws"
+    PLAN_OUT = "tfplan.out"
+    PLAN_SUMMARY = "tfplan-summary.txt"
   }
 
   options {
-    timestamps() // Agrega timestamps a los logs automáticamente
+    timestamps()
   }
 
   stages {
@@ -19,8 +21,10 @@ pipeline {
       steps {
         echo "[STEP] Starting environment preparation..."
         dir("${TF_DIR}") {
-          sh 'echo "[INFO] Current Terraform working directory: $(pwd)"'
-          sh 'terraform version'
+          sh '''
+            echo "[INFO] Current Terraform working directory: $(pwd)"
+            terraform version
+          '''
         }
       }
     }
@@ -36,7 +40,8 @@ pipeline {
               echo "[STEP] Exporting Terraform Cloud Token..."
               export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
 
-              echo "[STEP] Initializing Terraform backend and providers..."
+              echo "[STEP] Initializing Terraform backend (only for tfstate)..."
+              rm -rf .terraform
               terraform init -input=false
             '''
           }
@@ -44,36 +49,52 @@ pipeline {
       }
     }
 
-    stage('Terraform Validate') {
+    stage('Terraform Validate & Format') {
       steps {
         dir("${TF_DIR}") {
           sh '''
-            echo "[STEP] Validating Terraform code syntax..."
+            echo "[STEP] Formatting and validating Terraform code..."
+            terraform fmt -check
             terraform validate
           '''
         }
       }
     }
 
-    stage('Terraform Plan') {
+    stage('Terraform Plan (Local Execution)') {
       steps {
-        dir("${TF_DIR}") {
-          sh '''
-            echo "[STEP] Generating Terraform plan..."
-            terraform plan -input=false -out=tfplan.out
-          '''
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Forcing local Terraform plan execution..."
+              export TF_CLI_ARGS_plan="-input=false -lock=false -no-color"
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+
+              terraform plan -out=${PLAN_OUT} | tee ${PLAN_SUMMARY}
+            '''
+          }
         }
       }
     }
 
-    stage('Terraform Apply') {
+    stage('Terraform Apply (Local Execution)') {
       steps {
         input message: "[APPROVAL] Confirm Apply: Do you want to deploy these changes to AWS?"
-        dir("${TF_DIR}") {
-          sh '''
-            echo "[STEP] Applying Terraform plan to AWS..."
-            terraform apply -input=false tfplan.out
-          '''
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Forcing local Terraform apply execution..."
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+
+              terraform apply -input=false ${PLAN_OUT}
+            '''
+          }
         }
       }
     }
@@ -87,8 +108,9 @@ pipeline {
       echo "[FAILURE] Terraform process failed. Please review logs."
     }
     always {
-      sh 'echo "[INFO] Pipeline finished at: $(date)"'
-
+      sh '''
+        echo "[INFO] Pipeline finished at: $(date)"
+      '''
     }
   }
 }

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -13,103 +13,110 @@ pipeline {
   }
 
   options {
-        timestamps()
+    timestamps()
+  }
+
+  stages {
+    stage('Prepare Environment') {
+      steps {
+        echo "[STEP] Starting environment preparation..."
+        dir("${TF_DIR}") {
+          sh '''
+            echo "[INFO] Current Terraform working directory: $(pwd)"
+            terraform version
+          '''
+        }
+      }
     }
 
-    stages {
+    stage('Terraform Init') {
+      steps {
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Exporting Terraform Cloud Token..."
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
 
-        stage('Cleanup Before Checkout') {
-            steps {
-                deleteDir()
-            }
+              echo "[STEP] Initializing Terraform backend (only for tfstate)..."
+              rm -rf .terraform
+              terraform init -input=false
+            '''
+          }
         }
-
-        stage('Checkout') {
-            steps {
-                echo "[INFO] Checking out repository..."
-                checkout scm
-            }
-        }
-
-        stage('Terraform Init') {
-            steps {
-                withCredentials([
-                    [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
-                    [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
-                ]) {
-                    dir("${TF_DIR}") {
-                        echo "[DEBUG] Initializing Terraform..."
-                        sh '''
-                          rm -rf .terraform
-                          terraform init -input=false
-                        '''
-                    }
-                }
-            }
-        }
-
-        stage('Terraform Validate & Format') {
-            steps {
-                dir("${TF_DIR}") {
-                    echo "[DEBUG] Formatting and validating Terraform code..."
-                    sh 'terraform fmt -check'
-                    sh 'terraform validate'
-                }
-            }
-        }
-
-        stage('Terraform Plan') {
-            steps {
-                withCredentials([
-                    [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
-                ]) {
-                    dir("${TF_DIR}") {
-                        echo "[DEBUG] Forcing local terraform plan"
-                        sh '''
-                            export TF_CLI_ARGS_plan="-input=false -lock=false -no-color"
-                            export TF_IN_AUTOMATION=true
-                            export TF_CLOUD=false
-
-                            terraform plan -out=${PLAN_OUT} | tee ${PLAN_SUMMARY}
-                        '''
-                    }
-                }
-            }
-        }
-
-        stage('Terraform Apply') {
-            when {
-                expression {
-                    return currentBuild.currentResult == 'SUCCESS'
-                }
-            }
-            steps {
-                withCredentials([
-                    [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
-                ]) {
-                    dir("${TF_DIR}") {
-                        echo "[INFO] Applying Terraform changes..."
-                        sh '''
-                            export TF_IN_AUTOMATION=true
-                            export TF_CLOUD=false
-                            terraform apply -auto-approve
-                        '''
-                    }
-                }
-            }
-        }
+      }
     }
 
-    post {
-        success {
-            echo "[SUCCESS] Terraform plan pipeline completed successfully."
+    stage('Terraform Validate & Format') {
+      steps {
+        dir("${TF_DIR}") {
+          sh '''
+            echo "[STEP] Formatting and validating Terraform code..."
+            terraform fmt -check
+            terraform validate
+          '''
         }
-        failure {
-            echo "[FAILURE] Terraform plan pipeline failed. See logs for details."
-        }
-        always {
-            echo "[FINAL] Pipeline finished with status: ${currentBuild.result}"
-            cleanWs()
-        }
+      }
     }
+
+    stage('Terraform Plan (Local Execution)') {
+      steps {
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Forcing local Terraform plan execution..."
+              export TF_CLI_ARGS_plan="-input=false -lock=false -no-color"
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              terraform plan -out=tfplan.out | tee tfplan-summary.txt
+            '''
+
+          }
+        }
+      }
+    }
+
+    stage('Terraform Apply (Local Execution)') {
+      steps {
+        input message: "[APPROVAL] Confirm Apply: Do you want to deploy these changes to AWS?"
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Forcing local Terraform apply execution..."
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              terraform apply -input=false tfplan.out
+            '''
+
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    success {
+      echo "[SUCCESS] Terraform apply completed successfully. Infrastructure is deployed."
+    }
+    failure {
+      echo "[FAILURE] Terraform process failed. Please review logs."
+    }
+    always {
+      sh '''
+        echo "[INFO] Pipeline finished at: $(date)"
+      '''
+    }
+  }
 }

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -64,7 +64,8 @@ pipeline {
     stage('Terraform Plan (Local Execution)') {
       steps {
         withCredentials([
-          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
         ]) {
           dir("${TF_DIR}") {
             sh '''
@@ -84,7 +85,8 @@ pipeline {
       steps {
         input message: "[APPROVAL] Confirm Apply: Do you want to deploy these changes to AWS?"
         withCredentials([
-          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials']
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
         ]) {
           dir("${TF_DIR}") {
             sh '''

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -5,7 +5,7 @@ pipeline {
       defaultContainer 'terraform-aws'
     }
   }
-  
+
   environment {
     TF_DIR = "devops_CI_CD/terraform/aws"
     PLAN_OUT = "tfplan.out"
@@ -77,7 +77,6 @@ pipeline {
 
               terraform plan -out=tfplan.out | tee tfplan-summary.txt
             '''
-
           }
         }
       }
@@ -97,42 +96,43 @@ pipeline {
               export TF_CLOUD=false
               export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
 
-              terraform apply -auto-aprove -input=false tfplan.out
+              terraform apply -auto-approve -input=false tfplan.out
             '''
+          }
+        }
+      }
+    }
 
+    stage('Wait and Destroy Infrastructure') {
+      steps {
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[INFO] Waiting 60 seconds before destroying infrastructure..."
+              sleep 60
+
+              echo "[STEP] Destroying infrastructure..."
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              terraform destroy -auto-approve
+            '''
           }
         }
       }
     }
   }
-stage('Wait and Destroy Infrastructure') {
-  steps {
-    withCredentials([
-      [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
-      [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
-    ]) {
-      dir("${TF_DIR}") {
-        sh '''
-          echo "[INFO] Waiting 60 seconds before destroying infrastructure..."
-          sleep 60
 
-          echo "[STEP] Destroying infrastructure..."
-          export TF_IN_AUTOMATION=true
-          export TF_CLOUD=false
-          export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
-
-          terraform destroy -auto-approve
-        '''
-      }
-    }
-  }
-}
   post {
     success {
       echo "[SUCCESS] Terraform apply completed successfully. Infrastructure is deployed."
     }
     failure {
-      echo "[FAILURE] Terraform process failed. Please review logs."
+      echo "[FAILURE] Terraform process failed. See logs for details."
     }
     always {
       sh '''

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -1,0 +1,93 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'terraform-aws'
+      defaultContainer 'terraform-aws'
+    }
+  }
+  
+  environment {
+    TF_DIR = "terraform/aws" // Cambia si tu estructura del repo es distinta
+  }
+
+  options {
+    timestamps() // Agrega timestamps a los logs automáticamente
+  }
+
+  stages {
+    stage('Prepare Environment') {
+      steps {
+        echo "[STEP] Starting environment preparation..."
+        dir("${TF_DIR}") {
+          sh 'echo "[INFO] Current Terraform working directory: $(pwd)"'
+          sh 'terraform version'
+        }
+      }
+    }
+
+    stage('Terraform Init') {
+      steps {
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+          [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Exporting Terraform Cloud Token..."
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              echo "[STEP] Initializing Terraform backend and providers..."
+              terraform init -input=false
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Terraform Validate') {
+      steps {
+        dir("${TF_DIR}") {
+          sh '''
+            echo "[STEP] Validating Terraform code syntax..."
+            terraform validate
+          '''
+        }
+      }
+    }
+
+    stage('Terraform Plan') {
+      steps {
+        dir("${TF_DIR}") {
+          sh '''
+            echo "[STEP] Generating Terraform plan..."
+            terraform plan -input=false -out=tfplan.out
+          '''
+        }
+      }
+    }
+
+    stage('Terraform Apply') {
+      steps {
+        input message: "[APPROVAL] Confirm Apply: Do you want to deploy these changes to AWS?"
+        dir("${TF_DIR}") {
+          sh '''
+            echo "[STEP] Applying Terraform plan to AWS..."
+            terraform apply -input=false tfplan.out
+          '''
+        }
+      }
+    }
+  }
+
+  post {
+    success {
+      echo "[SUCCESS] Terraform apply completed successfully. Infrastructure is deployed."
+    }
+    failure {
+      echo "[FAILURE] Terraform process failed. Please review logs."
+    }
+    always {
+      echo "[INFO] Pipeline finished at: $(date)"
+    }
+  }
+}

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -97,7 +97,7 @@ pipeline {
               export TF_CLOUD=false
               export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
 
-              terraform apply -input=false tfplan.out
+              terraform apply -auto-aprove -input=false tfplan.out
             '''
 
           }
@@ -105,7 +105,28 @@ pipeline {
       }
     }
   }
+stage('Wait and Destroy Infrastructure') {
+  steps {
+    withCredentials([
+      [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-credentials'],
+      [$class: 'StringBinding', credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN']
+    ]) {
+      dir("${TF_DIR}") {
+        sh '''
+          echo "[INFO] Waiting 60 seconds before destroying infrastructure..."
+          sleep 60
 
+          echo "[STEP] Destroying infrastructure..."
+          export TF_IN_AUTOMATION=true
+          export TF_CLOUD=false
+          export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+          terraform destroy -auto-approve
+        '''
+      }
+    }
+  }
+}
   post {
     success {
       echo "[SUCCESS] Terraform apply completed successfully. Infrastructure is deployed."

--- a/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/aws/Jenkinsfile.infra
@@ -87,7 +87,8 @@ pipeline {
       echo "[FAILURE] Terraform process failed. Please review logs."
     }
     always {
-      echo "[INFO] Pipeline finished at: $(date)"
+      sh 'echo "[INFO] Pipeline finished at: $(date)"'
+
     }
   }
 }

--- a/devops_CI_CD/jenkins/gcp/Jenkinsfile.infra
+++ b/devops_CI_CD/jenkins/gcp/Jenkinsfile.infra
@@ -1,0 +1,160 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'terraform-gcp'
+      defaultContainer 'terraform-gcp'
+    }
+  }
+
+  environment {
+    TF_DIR = "devops_CI_CD/terraform/gcp"
+    PLAN_OUT = "tfplan.out"
+    PLAN_SUMMARY = "tfplan-summary.txt"
+  }
+
+  options {
+    timestamps()
+  }
+
+  stages {
+    stage('Prepare Environment') {
+      steps {
+        echo "[STEP] Starting environment preparation..."
+        dir("${TF_DIR}") {
+          sh '''
+            echo "[INFO] Current Terraform working directory: $(pwd)"
+            terraform version
+            gcloud version
+          '''
+        }
+      }
+    }
+
+    stage('Terraform Init') {
+      steps {
+        withCredentials([
+          file(credentialsId: 'gcp-service-account', variable: 'GCP_CREDS'),
+          string(credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN')
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Activating GCP Service Account..."
+              export GOOGLE_APPLICATION_CREDENTIALS=$GCP_CREDS
+              gcloud auth activate-service-account --key-file=$GCP_CREDS
+              gcloud auth list
+
+              echo "[STEP] Exporting Terraform Cloud Token..."
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              echo "[STEP] Initializing Terraform backend..."
+              rm -rf .terraform
+              terraform init -input=false
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Terraform Validate & Format') {
+      steps {
+        dir("${TF_DIR}") {
+          sh '''
+            echo "[STEP] Formatting and validating Terraform code..."
+            terraform fmt -check
+            terraform validate
+          '''
+        }
+      }
+    }
+
+    stage('Terraform Plan (Local Execution)') {
+      steps {
+        withCredentials([
+          file(credentialsId: 'gcp-service-account', variable: 'GCP_CREDS'),
+          string(credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN')
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Activating GCP Service Account again..."
+              export GOOGLE_APPLICATION_CREDENTIALS=$GCP_CREDS
+              gcloud auth activate-service-account --key-file=$GCP_CREDS
+
+              echo "[STEP] Forcing local Terraform plan execution..."
+              export TF_CLI_ARGS_plan="-input=false -lock=false -no-color"
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              terraform plan -out=tfplan.out | tee tfplan-summary.txt
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Terraform Apply (Local Execution)') {
+      steps {
+        withCredentials([
+          file(credentialsId: 'gcp-service-account', variable: 'GCP_CREDS'),
+          string(credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN')
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[STEP] Activating GCP Service Account again..."
+              export GOOGLE_APPLICATION_CREDENTIALS=$GCP_CREDS
+              gcloud auth activate-service-account --key-file=$GCP_CREDS
+
+              echo "[STEP] Forcing local Terraform apply execution..."
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              terraform apply -auto-approve -input=false tfplan.out
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Wait and Destroy Infrastructure') {
+      steps {
+        withCredentials([
+          file(credentialsId: 'gcp-service-account', variable: 'GCP_CREDS'),
+          string(credentialsId: 'terraform-cloud-token', variable: 'TERRAFORM_CLOUD_TOKEN')
+        ]) {
+          dir("${TF_DIR}") {
+            sh '''
+              echo "[INFO] Waiting 60 seconds before destroying infrastructure..."
+              sleep 60
+
+              echo "[STEP] Activating GCP Service Account again before destroy..."
+              export GOOGLE_APPLICATION_CREDENTIALS=$GCP_CREDS
+              gcloud auth activate-service-account --key-file=$GCP_CREDS
+
+              echo "[STEP] Destroying infrastructure..."
+              export TF_IN_AUTOMATION=true
+              export TF_CLOUD=false
+              export TF_TOKEN_app_terraform_io=$TERRAFORM_CLOUD_TOKEN
+
+              terraform destroy -auto-approve
+            '''
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    success {
+      echo "[SUCCESS] Terraform apply completed successfully. Infrastructure is deployed."
+    }
+    failure {
+      echo "[FAILURE] Terraform process failed. See logs for details."
+    }
+    always {
+      sh '''
+        echo "[INFO] Pipeline finished at: $(date)"
+      '''
+    }
+  }
+}

--- a/devops_CI_CD/terraform/aws/backend.tf
+++ b/devops_CI_CD/terraform/aws/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "remote" {
+    organization = "SoftServe_Devops"
+
+    workspaces {
+      name = "terraform-infra"
+    }
+  }
+}

--- a/devops_CI_CD/terraform/aws/data.tf
+++ b/devops_CI_CD/terraform/aws/data.tf
@@ -1,0 +1,10 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}

--- a/devops_CI_CD/terraform/aws/main.tf
+++ b/devops_CI_CD/terraform/aws/main.tf
@@ -1,0 +1,26 @@
+
+module "vpc" {
+  source     = "../modules/aws/vpc"
+  cidr_block = var.vpc_cidr
+}
+
+module "ec2" {
+  source            = "../modules/aws/ec2"
+  instance_type     = var.instance_type
+  ami_id            = data.aws_ami.ubuntu.id
+  subnet_id         = module.vpc.public_subnet_id
+  security_group_id = module.security_group.id
+}
+
+
+
+module "s3_bucket" {
+  source      = "../modules/aws/s3"
+  bucket_name = var.bucket_name
+  #env         = var.env
+}
+
+module "security_group" {
+  source = "../modules/aws/security_group"
+  vpc_id = module.vpc.vpc_id
+}

--- a/devops_CI_CD/terraform/aws/output.tf
+++ b/devops_CI_CD/terraform/aws/output.tf
@@ -1,0 +1,24 @@
+output "s3_bucket_name" {
+  description = "S3 bucket name for backups."
+  value       = module.s3_bucket.bucket_name
+}
+
+output "s3_bucket_url" {
+  description = "Public URL of the S3 bucket."
+  value       = "https://s3.amazonaws.com/${module.s3_bucket.bucket_name}"
+}
+
+output "vpc_id" {
+  description = "AWS VPC ID."
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnet_id" {
+  description = "Public Subnet ID."
+  value       = module.vpc.public_subnet_id
+}
+
+output "gitea_instance_public_ip" {
+  description = "Public IP of Gitea EC2 instance."
+  value       = module.ec2.public_ip
+}

--- a/devops_CI_CD/terraform/aws/provider.tf
+++ b/devops_CI_CD/terraform/aws/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/devops_CI_CD/terraform/aws/terraform.auto.tfvars
+++ b/devops_CI_CD/terraform/aws/terraform.auto.tfvars
@@ -1,0 +1,6 @@
+
+region        = "us-east-1"
+vpc_cidr      = "10.0.0.0/16"
+instance_type = "t2.micro"
+
+bucket_name = "bucket-gitea"

--- a/devops_CI_CD/terraform/aws/variable.tf
+++ b/devops_CI_CD/terraform/aws/variable.tf
@@ -1,0 +1,17 @@
+
+variable "region" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+variable "bucket_name" {
+  type = string
+}
+
+#

--- a/devops_CI_CD/terraform/aws/version.tf
+++ b/devops_CI_CD/terraform/aws/version.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/devops_CI_CD/terraform/gcp/backend.tf
+++ b/devops_CI_CD/terraform/gcp/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "remote" {
+    organization = "SoftServe_Devops"
+
+    workspaces {
+      name = "terraform-infra"
+    }
+  }
+}

--- a/devops_CI_CD/terraform/gcp/main.tf
+++ b/devops_CI_CD/terraform/gcp/main.tf
@@ -1,0 +1,38 @@
+module "gcp_network" {
+  source       = "../modules/gcp/gcp_network"
+  network_name = var.network_name
+  region       = var.region
+  cidr_block   = var.cidr_block
+  project_id   = var.project_id
+
+}
+
+
+module "compute_engine" {
+  source                = "../modules/gcp/compute_engine"
+  gitea_vm_name         = var.gitea_vm_name
+  machine_type          = var.machine_type
+  zone                  = var.zone
+  image                 = var.image
+  network               = module.gcp_network.vpc_network_id          # <-- importante
+  subnetwork            = module.gcp_network.subnet_public_self_link # <-- nuevo
+  tags                  = var.instance_tags
+  gitea_secret_user     = var.gitea_secret_user
+  gitea_secret_password = var.gitea_secret_password
+}
+
+
+module "firewall" {
+  source        = "../modules/gcp/firewall"
+  network       = module.gcp_network.vpc_network_id # <-- importante, network es un output del módulo de red
+  gitea_vm_name = var.gitea_vm_name
+  target_tags   = var.instance_tags
+  depends_on    = [module.gcp_network] # <-- importante, depende de la red
+
+}
+
+module "gcs_bucket" {
+  source      = "../modules/gcp/gcs_bucket"
+  bucket_name = var.bucket_name
+  region      = var.region
+}

--- a/devops_CI_CD/terraform/gcp/outputs.tf
+++ b/devops_CI_CD/terraform/gcp/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_network_id" {
+  description = "VPC network ID."
+  value       = module.gcp_network.vpc_network_id
+}
+
+output "public_subnet_self_link" {
+  description = "Public subnet self-link."
+  value       = module.gcp_network.subnet_public_self_link
+}
+
+output "gitea_instance_public_ip" {
+  description = "Public IP of Gitea instance."
+  value       = module.compute_engine.public_ip
+}
+
+output "gcs_bucket_name" {
+  description = "GCS bucket name for backups."
+  value       = module.gcs_bucket.bucket_name
+}
+
+output "gcs_bucket_url" {
+  description = "Public URL of the GCS bucket."
+  value       = "https://storage.cloud.google.com/${module.gcs_bucket.bucket_name}"
+}

--- a/devops_CI_CD/terraform/gcp/provider.tf
+++ b/devops_CI_CD/terraform/gcp/provider.tf
@@ -1,0 +1,10 @@
+provider "google" {
+  project                     = var.project_id
+  region                      = var.region
+  zone                        = var.zone
+  impersonate_service_account = var.impersonate_service_account
+  credentials                 = null
+
+}
+
+

--- a/devops_CI_CD/terraform/gcp/terraform.auto.tfvars
+++ b/devops_CI_CD/terraform/gcp/terraform.auto.tfvars
@@ -1,0 +1,15 @@
+
+network_name          = "gitea-dr-network"
+region                = "us-central1"
+cidr_block            = "10.10.0.0/16"
+gitea_secret_user     = "gitea-user"
+gitea_secret_password = "gitea-password"
+
+gitea_vm_name               = "gitea-vm"
+machine_type                = "e2-medium"
+zone                        = "us-central1-a"
+image                       = "ubuntu-os-cloud/ubuntu-2204-lts"
+instance_tags               = ["gitea", "web"]
+project_id                  = "gitea-dr-457918"
+bucket_name                 = "bucket-gitea"
+impersonate_service_account = "terraform-dr@gitea-dr-457918.iam.gserviceaccount.com" 

--- a/devops_CI_CD/terraform/gcp/variables.tf
+++ b/devops_CI_CD/terraform/gcp/variables.tf
@@ -1,0 +1,27 @@
+
+variable "network_name" {}
+
+variable "region" {}
+
+variable "cidr_block" {}
+
+variable "gitea_vm_name" {}
+
+variable "machine_type" {}
+
+variable "zone" {}
+
+variable "image" {}
+
+variable "instance_tags" {}
+
+variable "gitea_secret_user" {}
+
+variable "gitea_secret_password" {}
+
+
+variable "project_id" {}
+
+variable "bucket_name" {}
+
+variable "impersonate_service_account" {}

--- a/devops_CI_CD/terraform/gcp/version.tf
+++ b/devops_CI_CD/terraform/gcp/version.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0"
+    }
+  }
+
+  required_version = ">= 1.3.0"
+}

--- a/devops_CI_CD/terraform/modules/aws/ec2/main.tf
+++ b/devops_CI_CD/terraform/modules/aws/ec2/main.tf
@@ -1,0 +1,12 @@
+
+resource "aws_instance" "gitea_web" {
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
+
+
+  tags = {
+    Name = "AWS-EC2"
+  }
+}

--- a/devops_CI_CD/terraform/modules/aws/ec2/output.tf
+++ b/devops_CI_CD/terraform/modules/aws/ec2/output.tf
@@ -1,0 +1,4 @@
+
+output "public_ip" {
+  value = aws_instance.gitea_web.public_ip
+}

--- a/devops_CI_CD/terraform/modules/aws/ec2/variables.tf
+++ b/devops_CI_CD/terraform/modules/aws/ec2/variables.tf
@@ -1,0 +1,5 @@
+
+variable "instance_type" {}
+variable "ami_id" {}
+variable "subnet_id" {}
+variable "security_group_id" {}

--- a/devops_CI_CD/terraform/modules/aws/s3/main.tf
+++ b/devops_CI_CD/terraform/modules/aws/s3/main.tf
@@ -1,0 +1,40 @@
+resource "aws_s3_bucket" "gitea_bucket" {
+  bucket = var.bucket_name
+
+  force_destroy = true
+
+  tags = {
+    Name = "gitea-bucket"
+
+    Project = "dr"
+  }
+}
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.gitea_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
+  bucket = aws_s3_bucket.gitea_bucket.id
+
+  rule {
+    id     = "DeleteOldVersions"
+    status = "Enabled"
+    filter {
+      prefix = ""
+    }
+
+
+    expiration {
+      days = 365
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 365
+    }
+
+
+  }
+}

--- a/devops_CI_CD/terraform/modules/aws/s3/output.tf
+++ b/devops_CI_CD/terraform/modules/aws/s3/output.tf
@@ -1,0 +1,4 @@
+
+output "bucket_name" {
+  value = aws_s3_bucket.gitea_bucket.bucket
+}

--- a/devops_CI_CD/terraform/modules/aws/s3/variables.tf
+++ b/devops_CI_CD/terraform/modules/aws/s3/variables.tf
@@ -1,0 +1,3 @@
+
+variable "bucket_name" {}
+#variable "env" {}

--- a/devops_CI_CD/terraform/modules/aws/security_group/main.tf
+++ b/devops_CI_CD/terraform/modules/aws/security_group/main.tf
@@ -1,0 +1,20 @@
+
+resource "aws_security_group" "security_group" {
+  name        = "terraform-sg"
+  description = "Allow HTTP"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/devops_CI_CD/terraform/modules/aws/security_group/output.tf
+++ b/devops_CI_CD/terraform/modules/aws/security_group/output.tf
@@ -1,0 +1,4 @@
+
+output "id" {
+  value = aws_security_group.security_group.id
+}

--- a/devops_CI_CD/terraform/modules/aws/security_group/variables.tf
+++ b/devops_CI_CD/terraform/modules/aws/security_group/variables.tf
@@ -1,0 +1,2 @@
+
+variable "vpc_id" {}

--- a/devops_CI_CD/terraform/modules/aws/vpc/main.tf
+++ b/devops_CI_CD/terraform/modules/aws/vpc/main.tf
@@ -1,0 +1,11 @@
+
+resource "aws_vpc" "gitea_main" {
+  cidr_block = var.cidr_block
+}
+
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.gitea_main.id
+  cidr_block        = cidrsubnet(var.cidr_block, 8, 0)
+  availability_zone = "us-east-1a"
+}
+

--- a/devops_CI_CD/terraform/modules/aws/vpc/output.tf
+++ b/devops_CI_CD/terraform/modules/aws/vpc/output.tf
@@ -1,0 +1,9 @@
+
+output "vpc_id" {
+  value = aws_vpc.gitea_main.id
+}
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}
+

--- a/devops_CI_CD/terraform/modules/aws/vpc/variables.tf
+++ b/devops_CI_CD/terraform/modules/aws/vpc/variables.tf
@@ -1,0 +1,2 @@
+
+variable "cidr_block" {}

--- a/devops_CI_CD/terraform/modules/gcp/compute_engine/main.tf
+++ b/devops_CI_CD/terraform/modules/gcp/compute_engine/main.tf
@@ -1,0 +1,24 @@
+# GCP Compute Engine Module
+resource "google_compute_instance" "this" {
+  name                = var.gitea_vm_name
+  machine_type        = var.machine_type
+  zone                = var.zone
+  deletion_protection = false
+
+  boot_disk {
+    initialize_params {
+      image = var.image
+    }
+  }
+
+  network_interface {
+    network    = var.network
+    subnetwork = var.subnetwork
+    access_config {}
+  }
+
+
+
+
+  tags = var.tags
+}

--- a/devops_CI_CD/terraform/modules/gcp/compute_engine/outputs.tf
+++ b/devops_CI_CD/terraform/modules/gcp/compute_engine/outputs.tf
@@ -1,0 +1,20 @@
+output "gitea_vm_name" {
+  value       = google_compute_instance.this.name
+  description = "Name of the Gitea VM instance"
+}
+
+output "gitea_vm_ip" {
+  value       = google_compute_instance.this.network_interface[0].access_config[0].nat_ip
+  description = "Public IP address of the Gitea VM"
+}
+
+output "zone" {
+  value       = google_compute_instance.this.zone
+  description = "Zone where the Gitea VM is deployed"
+}
+
+
+output "public_ip" {
+  description = "Public IP address of the Gitea instance."
+  value       = google_compute_instance.this.network_interface[0].access_config[0].nat_ip
+}

--- a/devops_CI_CD/terraform/modules/gcp/compute_engine/variables.tf
+++ b/devops_CI_CD/terraform/modules/gcp/compute_engine/variables.tf
@@ -1,0 +1,43 @@
+variable "gitea_vm_name" {
+  type        = string
+  description = "Name of the Gitea virtual machine"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for the instance (e.g. e2-micro)"
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone to deploy the instance (e.g. us-central1-a)"
+}
+
+variable "image" {
+  type        = string
+  description = "Boot disk image (e.g. debian-cloud/debian-11)"
+}
+
+variable "network" {
+  type        = string
+  description = "Name or self_link of the VPC network"
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "List of tags to apply to the instance"
+}
+
+variable "gitea_secret_user" {
+  type        = string
+  description = "Name of the Secret Manager secret that holds the SSH username"
+}
+
+variable "gitea_secret_password" {
+  type        = string
+  description = "Name of the Secret Manager secret that holds the SSH public key"
+}
+variable "subnetwork" {
+  description = "Subnetwork self_link or name for the Gitea VM"
+  type        = string
+}

--- a/devops_CI_CD/terraform/modules/gcp/firewall/main.tf
+++ b/devops_CI_CD/terraform/modules/gcp/firewall/main.tf
@@ -1,0 +1,14 @@
+resource "google_compute_firewall" "allow_http" {
+  name    = "${var.gitea_vm_name}-fw-http"
+  network = var.network
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+
+  target_tags = var.target_tags
+
+  source_ranges = ["0.0.0.0/0"]
+  direction     = "INGRESS"
+}

--- a/devops_CI_CD/terraform/modules/gcp/firewall/outputs.tf
+++ b/devops_CI_CD/terraform/modules/gcp/firewall/outputs.tf
@@ -1,0 +1,5 @@
+output "http_rule_name" {
+  value       = google_compute_firewall.allow_http.name
+  description = "Name of the HTTP firewall rule"
+}
+

--- a/devops_CI_CD/terraform/modules/gcp/firewall/variables.tf
+++ b/devops_CI_CD/terraform/modules/gcp/firewall/variables.tf
@@ -1,0 +1,14 @@
+variable "network" {
+  type        = string
+  description = "Name or self_link of the VPC network"
+}
+
+variable "gitea_vm_name" {
+  type        = string
+  description = "Name of the Gitea VM (used in firewall naming)"
+}
+
+variable "target_tags" {
+  type        = list(string)
+  description = "List of tags to match VM targets for firewall rules"
+}

--- a/devops_CI_CD/terraform/modules/gcp/gcp_network/main.tf
+++ b/devops_CI_CD/terraform/modules/gcp/gcp_network/main.tf
@@ -1,0 +1,26 @@
+resource "google_compute_network" "vpc_network" {
+  name                    = var.network_name
+  auto_create_subnetworks = false
+  description             = "VPC for ${var.network_name}"
+  project                 = var.project_id
+}
+
+locals {
+  subnet_definition = {
+    name       = "public"
+    new_bits   = 8
+    netnum     = 0
+    private_ip = false
+  }
+}
+
+
+
+resource "google_compute_subnetwork" "public_subnet" {
+  name                     = "${var.network_name}-public"
+  ip_cidr_range            = cidrsubnet(var.cidr_block, local.subnet_definition.new_bits, local.subnet_definition.netnum)
+  region                   = var.region
+  network                  = google_compute_network.vpc_network.id
+  private_ip_google_access = local.subnet_definition.private_ip
+  description              = "Public subnet for ${var.network_name}"
+}

--- a/devops_CI_CD/terraform/modules/gcp/gcp_network/outputs.tf
+++ b/devops_CI_CD/terraform/modules/gcp/gcp_network/outputs.tf
@@ -1,0 +1,15 @@
+
+output "network_self_link" {
+  value = google_compute_network.vpc_network.self_link
+}
+
+
+output "vpc_network_id" {
+  description = "Self link of the VPC network"
+  value       = google_compute_network.vpc_network.id
+}
+
+output "subnet_public_self_link" {
+  description = "Self link of the public subnet"
+  value       = google_compute_subnetwork.public_subnet.self_link
+}

--- a/devops_CI_CD/terraform/modules/gcp/gcp_network/variables.tf
+++ b/devops_CI_CD/terraform/modules/gcp/gcp_network/variables.tf
@@ -1,0 +1,22 @@
+variable "network_name" {
+  type        = string
+  description = "Name of the VPC network"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region"
+}
+
+variable "cidr_block" {
+  type        = string
+  description = "Base CIDR block for the entire VPC (e.g. 10.10.0.0/16)"
+}
+# variable "project" {
+#   description = "ID del proyecto en GCP"
+#   type        = string
+# }
+variable "project_id" {
+  description = "ID of the GCP project"
+  type        = string
+}

--- a/devops_CI_CD/terraform/modules/gcp/gcs_bucket/main.tf
+++ b/devops_CI_CD/terraform/modules/gcp/gcs_bucket/main.tf
@@ -1,0 +1,25 @@
+resource "google_storage_bucket" "gitea_bucket" {
+  name          = var.bucket_name
+  location      = var.region
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      age = 365
+    }
+  }
+
+  labels = {
+    app = "gitea"
+    env = "dr"
+  }
+}

--- a/devops_CI_CD/terraform/modules/gcp/gcs_bucket/outputs.tf
+++ b/devops_CI_CD/terraform/modules/gcp/gcs_bucket/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  value       = google_storage_bucket.gitea_bucket.name
+  description = "The name of the created GCS bucket"
+}
+
+output "bucket_url" {
+  value       = google_storage_bucket.gitea_bucket.url
+  description = "URL of the GCS bucket"
+}

--- a/devops_CI_CD/terraform/modules/gcp/gcs_bucket/variables.tf
+++ b/devops_CI_CD/terraform/modules/gcp/gcs_bucket/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the GCS bucket to create"
+}
+
+variable "region" {
+  type        = string
+  description = "Region in which the bucket will be created"
+}


### PR DESCRIPTION
This PR sets up the infrastructure provisioning pipeline for AWS using Terraform and Jenkins.  
Key work includes:

- Creating and adjusting the Jenkinsfile for provisioning workflows.
- Resolving shell command incompatibilities (`sh` vs `echo`).
- Fixing path errors and backend credential issues.
- Enabling local Terraform plan/apply for early testing.
- Adding auto-destroy logic for resource lifecycle testing.
- Cleaning up indentation and formatting.

Also includes initial GCP provisioning setup under SCRM-107.
